### PR TITLE
add GCP Notebook CSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Where possible I also want to ensure customers know what steps they can take to 
   - https://www.upguard.com/breaches/identity-and-access-misstep-how-an-amazon-engineer-exposed-credentials-and-more
 
 
+### GCP: AI Hub Jupyter Notebook instance CSRF
+Summary: AI Hub Jupyter Notebook server lacked a check of the Origin header that led to a CSRF vulnerability. An attacker could have read sensitive data and execute arbitrary actions in customer environments.
+Platform: GCP
+Severity: Medium
+Date: March 10, 2020
+Discoverer: s1r1us
+Customer action: N/A
+References:
+https://blog.s1r1us.ninja/research/cookie-tossing-to-rce-on-google-cloud-jupyter-notebooks
+
+
 ### AWS: GuardDuty detection bypass via cloudtrail:PutEventSelectors
 - Summary: GuardDuty detects CloudTrail being disabled, but did not detect if you filtered out all events from CloudTrail, resulting in defenders having no logs to review. Require privileged access in victim account, resulting in limited visibility.
 - Platform: AWS


### PR DESCRIPTION
When researching the "AWS SageMaker Jupyter Notebook instance CSRF" issue, I noticed it was almost a carbon copy of some research done in GCP over a year and a half earlier (if the dates are accurate). This does not invalidate the talent of either researcher. I must assume both issues were found independently since I am not seeing attribution in the latest reference. In my opinion, this is an important addition because it highlights a huge issue. AWS Notebooks were vulnerable to an issue that was reported over a year and a half earlier. I would guess this happened because there was no CVE associated with this issue?